### PR TITLE
change link to a usable calendar

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -17,7 +17,7 @@ block content
 				li: a(href='http://shackspace.de/wiki') 
 					.fa.fa-book
 					| Wiki
-				li: a(href='https://blog.shack.space/?cat=12') 
+				li: a(href='https://calendar.google.com/calendar/embed?src=q4rffe7pskgkfc7sr3cmvcmavc@group.calendar.google.com&ctz=Europe/Berlin') 
 					.fa.fa-calendar
 					| Events
 


### PR DESCRIPTION
Right now the link points to the blog category with events. this is not useful when you are `really` searching for events in the shackspace.
The PR changes the link to the google calendar for Raum Planung.